### PR TITLE
Remove the fallback-x11 socket

### DIFF
--- a/com.zandronum.Zandronum.yaml
+++ b/com.zandronum.Zandronum.yaml
@@ -7,7 +7,6 @@ command: doomseeker
 finish-args:
 - --device=dri
 - --socket=wayland
-- --socket=fallback-x11
 - --socket=x11
 - --share=ipc
 - --share=network


### PR DESCRIPTION
Fixes #4

While Doomseeker works natively on Wayland, Zandronum seems to always be using the x11 SDL backend. However, the `fallback-x11` socket does seem to make Zandronum not being able to find the SDL video device. I have kept the `wayland` socket because with just `x11` socket enabled, issue #6 happens.

/cc @Eonfge